### PR TITLE
Pin single docker base image from commandline argument

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -28,8 +28,8 @@ var (
 	}
 
 	dockerBaseCmd = &cobra.Command{
-		Use:          "docker-base base-image",
-		Example:      "docker-base ubuntu:20.04",
+		Use:          "resolve [base image]",
+		Example:      "resolve ubuntu:20.04",
 		Short:        "Prints the current digest of the given base image",
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: false,

--- a/docker.go
+++ b/docker.go
@@ -76,8 +76,9 @@ func runDockerResolve(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	hashedBase := baseImageAndVersion + "@" + string(di.Descriptor.Digest) + "\n"
-	return ioutil.WriteFile("/dev/stdout", []byte(hashedBase), 0644)
+	hashedBase := baseImageAndVersion + "@" + string(di.Descriptor.Digest)
+	_, err = fmt.Println(hashedBase)
+	return err
 }
 
 func ifDash(fn string, repl string) string {

--- a/docker.go
+++ b/docker.go
@@ -32,7 +32,7 @@ var (
 		Short:        "Prints the current digest of the given base image",
 		Args:         cobra.ExactArgs(1),
 		SilenceUsage: true,
-		RunE:         runDockerBasePin,
+		RunE:         runDockerResolve,
 	}
 
 	dockerfile *string
@@ -66,7 +66,7 @@ func runDockerPin(cmd *cobra.Command, args []string) error {
 	return ioutil.WriteFile(ifDash(*dockerfile, "/dev/stdout"), n, 0644)
 }
 
-func runDockerBasePin(cmd *cobra.Command, args []string) error {
+func runDockerResolve(cmd *cobra.Command, args []string) error {
 	baseImageAndVersion := args[0]
 	dockerClient, err := docker.NewClientWithOpts(docker.FromEnv)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 	aptCmd.AddCommand(aptPinCmd)
 	aptCmd.AddCommand(aptInstallCmd)
 	dockerCmd.AddCommand(dockerPinCmd)
-	dockerCmd.AddCommand(dockerBaseCmd)
+	dockerCmd.AddCommand(dockerResolveCmd)
 	rootCmd.AddCommand(aptCmd)
 	rootCmd.AddCommand(dockerCmd)
 	if err := rootCmd.Execute(); err != nil {

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 	dockerCmd.AddCommand(dockerPinCmd)
 	rootCmd.AddCommand(aptCmd)
 	rootCmd.AddCommand(dockerCmd)
+	rootCmd.AddCommand(dockerBaseCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -19,9 +19,9 @@ func main() {
 	aptCmd.AddCommand(aptPinCmd)
 	aptCmd.AddCommand(aptInstallCmd)
 	dockerCmd.AddCommand(dockerPinCmd)
+	dockerCmd.AddCommand(dockerBaseCmd)
 	rootCmd.AddCommand(aptCmd)
 	rootCmd.AddCommand(dockerCmd)
-	rootCmd.AddCommand(dockerBaseCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
Fetch the latest hash for a single docker base image supplied as commandline argument.

Example:
```
$ dockpin docker-base ubuntu:16.04
ubuntu@sha256:0f71fa8d4d2d4292c3c617fda2b36f6dabe5c8b6e34c3dc5b0d17d4e704bd39c
```

This makes it easier to pin docker base images in other files than Dockerfiles, eg. circleci yml files, [like this](https://gist.github.com/oh6hay/a7195da72c7de5a389cfa280a97ff07d)