### PR TITLE
Optional authentication flags for Docker client

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -46,8 +46,8 @@ var (
 func init() {
 	dockerfile = rootCmd.PersistentFlags().StringP("dockerfile", "f", "Dockerfile", "Path to your Dockerfile (or - for stdin)")
 	rootCmd.MarkPersistentFlagFilename("dockerfile")
-	username = rootCmd.PersistentFlags().StringP("username", "u", "", "Username to authenticate with to the Docker registry")
-	password = rootCmd.PersistentFlags().StringP("password", "p", "", "Password to authenticate with to the Docker registry")
+	username = dockerCmd.PersistentFlags().StringP("username", "u", "", "Username to authenticate with to the Docker registry")
+	password = dockerCmd.PersistentFlags().StringP("password", "p", "", "Password to authenticate with to the Docker registry")
 }
 
 func authStringForCommand(cmd *cobra.Command) string {


### PR DESCRIPTION
Some docker registries require authentication

With authentication:
```
dockpin docker pin -f Dockerfile.foo -u username -p password
```
or
```
dockpin docker resolve your.private.registry/foobar:20.04 -u username -p password
```
