### PR TITLE
Docker check command

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func main() {
 	aptCmd.AddCommand(aptInstallCmd)
 	dockerCmd.AddCommand(dockerPinCmd)
 	dockerCmd.AddCommand(dockerResolveCmd)
+	dockerCmd.AddCommand(dockerCheckCmd)
 	rootCmd.AddCommand(aptCmd)
 	rootCmd.AddCommand(dockerCmd)
 	if err := rootCmd.Execute(); err != nil {


### PR DESCRIPTION
The `docker check` command reads a Dockerfile, checks each base image reference, and prints a message if any of the base images are not tagged at the latest checksum. Also, if not all images are tagged latest, the main executable returns a nonzero value (might be useful in a CI pipeline, for example):
```
#!/bin/bash
# this is a CI job
if dockpin docker check -f ./Dockerfile ; then
  echo maybe update your Dockerfile
fi
# ...
```
